### PR TITLE
Refactor/pick image in post

### DIFF
--- a/app/src/main/java/ch/epfl/sdp/kandle/activity/CustomAccountActivity.java
+++ b/app/src/main/java/ch/epfl/sdp/kandle/activity/CustomAccountActivity.java
@@ -8,6 +8,9 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageView;
 import androidx.appcompat.app.AppCompatActivity;
+
+import com.google.android.gms.tasks.Task;
+
 import ch.epfl.sdp.kandle.MainActivity;
 import ch.epfl.sdp.kandle.R;
 import ch.epfl.sdp.kandle.imagePicker.ProfilePicPicker;
@@ -19,14 +22,15 @@ import ch.epfl.sdp.kandle.dependencies.DependencyManager;
 public class CustomAccountActivity extends AppCompatActivity {
 
     public final static int PROFILE_PICTURE_TAG = 12;
-    private ProfilePicPicker profilePicPicker;
 
-    Button uploadButton;
-    Button leaveButton;
-    ImageView profilePic;
-    EditText m_nickname;
+    private Button uploadButton;
+    private Button leaveButton;
+    private ImageView profilePic;
+    private EditText m_nickname;
 
-    Database database;
+    private Database database;
+
+    private Uri imageUri;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -39,26 +43,35 @@ public class CustomAccountActivity extends AppCompatActivity {
         leaveButton = findViewById(R.id.startButton);
         profilePic = findViewById(R.id.profilePic);
         m_nickname = findViewById(R.id.nickname);
-        profilePicPicker = new ProfilePicPicker(this);
-        uploadButton.setOnClickListener(v -> profilePicPicker.openImage());
+        uploadButton.setOnClickListener(v -> ProfilePicPicker.openImage(this));
 
         leaveButton.setOnClickListener(v -> {
-            ProgressDialog pd = new ProgressDialog(CustomAccountActivity.this);
-            pd.setMessage("Finalizing your account");
-            pd.show();
-            profilePicPicker.setProfilePicture().addOnCompleteListener(task -> {
-                String nickname = m_nickname.getText().toString().trim();
-                if (nickname.length() > 0) {
-                    database.updateNickname(nickname).addOnCompleteListener(task1 -> {
-                        pd.dismiss();
-                        startMainActivity();;
-                    });
+            String nickname = m_nickname.getText().toString().trim();
+            if (imageUri == null && nickname.length() == 0) {
+                startMainActivity();
+            }
+            else {
+                ProgressDialog pd = new ProgressDialog(CustomAccountActivity.this);
+                pd.setMessage("Finalizing your account");
+                pd.show();
+
+                Task<Void> task;
+                if (imageUri != null) {
+                    task = ProfilePicPicker.setProfilePicture(imageUri);
+                    if (nickname.length() > 0) {
+                        task.continueWith(t -> database.updateNickname(nickname));
+                    }
                 }
                 else {
+                    task = database.updateNickname(nickname);
+                }
+
+                task.addOnCompleteListener(t -> {
                     pd.dismiss();
                     startMainActivity();
-                }
-            });
+                });
+            }
+
         });
     }
 
@@ -71,12 +84,11 @@ public class CustomAccountActivity extends AppCompatActivity {
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        profilePicPicker.handleActivityResult(requestCode, resultCode, data);
-        Uri uri = profilePicPicker.getImageUri();
+        imageUri = ProfilePicPicker.handleActivityResultAndGetUri(requestCode, resultCode, data);
 
-        if (uri != null) {
+        if (imageUri != null) {
             profilePic.setTag(PROFILE_PICTURE_TAG);
-            profilePic.setImageURI(uri);
+            profilePic.setImageURI(imageUri);
         }
     }
 

--- a/app/src/main/java/ch/epfl/sdp/kandle/fragment/FollowingPostsFragment.java
+++ b/app/src/main/java/ch/epfl/sdp/kandle/fragment/FollowingPostsFragment.java
@@ -31,6 +31,8 @@ import static ch.epfl.sdp.kandle.fragment.YourPostListFragment.POST_IMAGE;
 
 public class FollowingPostsFragment extends Fragment {
 
+    //TODO should not be able to delete posts other users made
+
     private String userId;
     private List<User> following;
     private List<Post> posts;

--- a/app/src/main/java/ch/epfl/sdp/kandle/fragment/ProfileFragment.java
+++ b/app/src/main/java/ch/epfl/sdp/kandle/fragment/ProfileFragment.java
@@ -26,6 +26,8 @@ import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
+
+import ch.epfl.sdp.kandle.imagePicker.ImagePicker;
 import ch.epfl.sdp.kandle.imagePicker.ProfilePicPicker;
 import ch.epfl.sdp.kandle.LoggedInUser;
 import ch.epfl.sdp.kandle.R;
@@ -41,7 +43,6 @@ public class ProfileFragment extends Fragment {
     public final static int PROFILE_PICTURE_BEFORE = 6;
     public final static int PROFILE_PICTURE_AFTER = 7;
     private User user;
-    private ProfilePicPicker profilePicPicker;
     private ImageView mProfilePicture, mEditPicture, mProfilePictureInMenu, mEditName;
     private TextView mNumberOfFollowers, mNumberOfFollowing, mUsername, mNicknameView, mNickNameInMenu;
     private EditText mNicknameEdit;
@@ -49,6 +50,7 @@ public class ProfileFragment extends Fragment {
     private Button mFollowButton, mValidateNameButton, mValidatePictureButton;
     private Authentication auth;
     private Database database;
+    private Uri imageUri;
 
     private ProfileFragment(User user) {
         this.user = user;
@@ -85,8 +87,6 @@ public class ProfileFragment extends Fragment {
         auth = DependencyManager.getAuthSystem();
         database = new CachedDatabase();
 
-        profilePicPicker = new ProfilePicPicker(this);
-
         getViews(view);
 
         final User currentUser = LoggedInUser.getInstance();
@@ -100,7 +100,7 @@ public class ProfileFragment extends Fragment {
         } else {
             mEditPicture.setOnClickListener(v -> {
                 mEditPicture.setVisibility(View.GONE);
-                profilePicPicker.openImage();
+                ProfilePicPicker.openImage(this);
                 mValidatePictureButton.setVisibility(View.VISIBLE);
             });
 
@@ -136,9 +136,9 @@ public class ProfileFragment extends Fragment {
             ProgressDialog pd = new ProgressDialog(getContext());
             pd.setMessage("uploading");
             pd.show();
-            profilePicPicker.setProfilePicture().addOnCompleteListener(task -> {
+            ProfilePicPicker.setProfilePicture(imageUri).addOnCompleteListener(task -> {
                 mProfilePictureInMenu.setTag(PROFILE_PICTURE_AFTER);
-                mProfilePictureInMenu.setImageURI(profilePicPicker.getImageUri());
+                mProfilePictureInMenu.setImageURI(imageUri);
                 pd.dismiss();
             });
             mValidatePictureButton.setVisibility(View.GONE);
@@ -257,12 +257,11 @@ public class ProfileFragment extends Fragment {
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        profilePicPicker.handleActivityResult(requestCode, resultCode, data);
-        Uri uri = profilePicPicker.getImageUri();
+        imageUri = ProfilePicPicker.handleActivityResultAndGetUri(requestCode, resultCode, data);
 
-        if (uri != null) {
+        if (imageUri != null) {
             mProfilePicture.setTag(PROFILE_PICTURE_AFTER);
-            mProfilePicture.setImageURI(uri);
+            mProfilePicture.setImageURI(imageUri);
         }
     }
 }

--- a/app/src/main/java/ch/epfl/sdp/kandle/fragment/ProfileFragment.java
+++ b/app/src/main/java/ch/epfl/sdp/kandle/fragment/ProfileFragment.java
@@ -101,7 +101,6 @@ public class ProfileFragment extends Fragment {
             mEditPicture.setOnClickListener(v -> {
                 mEditPicture.setVisibility(View.GONE);
                 ProfilePicPicker.openImage(this);
-                mValidatePictureButton.setVisibility(View.VISIBLE);
             });
 
         }
@@ -262,6 +261,7 @@ public class ProfileFragment extends Fragment {
         if (imageUri != null) {
             mProfilePicture.setTag(PROFILE_PICTURE_AFTER);
             mProfilePicture.setImageURI(imageUri);
+            mValidatePictureButton.setVisibility(View.VISIBLE);
         }
     }
 }

--- a/app/src/main/java/ch/epfl/sdp/kandle/imagePicker/ImagePicker.java
+++ b/app/src/main/java/ch/epfl/sdp/kandle/imagePicker/ImagePicker.java
@@ -9,7 +9,6 @@ import android.webkit.MimeTypeMap;
 import androidx.fragment.app.Fragment;
 
 import com.google.android.gms.tasks.Task;
-import com.google.android.gms.tasks.TaskCompletionSource;
 
 import ch.epfl.sdp.kandle.Kandle;
 import ch.epfl.sdp.kandle.dependencies.DependencyManager;
@@ -19,28 +18,22 @@ import static android.app.Activity.RESULT_OK;
 
 public class ImagePicker {
 
-    //private Activity activity;
-    //private Fragment fragment;
-    //private Uri imageUri;
-
     private static final int IMAGE_REQUEST = 1;
-    /*public void openImage() {
-        Intent intent = new Intent();
-        intent.setType("image/*");
-        intent.setAction(Intent.ACTION_GET_CONTENT);
-        if (activity != null) {
-            activity.startActivityForResult(intent, IMAGE_REQUEST);
-        }
-        if (fragment != null) {
-            fragment.startActivityForResult(intent, IMAGE_REQUEST);
-        }
-    }*/
 
+    /**
+     * Starts picking an image from the gallery
+     * @param activity the activity where to return after picking an image
+     *
+     */
     public static void openImage(Activity activity) {
         Intent intent = pickerIntent();
         activity.startActivityForResult(intent, IMAGE_REQUEST);
     }
 
+    /**
+     * Starts picking an image from the gallery
+     * @param fragment the fragment where to return after picking an image
+     */
     public static void openImage(Fragment fragment) {
         Intent intent = pickerIntent();
         fragment.startActivityForResult(intent, IMAGE_REQUEST);
@@ -53,16 +46,18 @@ public class ImagePicker {
         return intent;
     }
 
-    /*private String getFileExtension(Uri uri) {
-        ContentResolver contentResolver = Kandle.getContext().getContentResolver();
-        return MimeTypeMap.getSingleton().getExtensionFromMimeType(contentResolver.getType(uri));
-    }*/
-
-    public static String getFileExtension(Uri uri) {
+    private static String getFileExtension(Uri uri) {
         ContentResolver contentResolver = Kandle.getContext().getContentResolver();
         return MimeTypeMap.getSingleton().getExtensionFromMimeType(contentResolver.getType(uri));
     }
 
+    /**
+     * Checks the result received from an activity and returns an image uri if the result corresponds to a pick in the gallery
+     * @param requestCode requestCode specified when starting the activity
+     * @param resultCode resultCode received in the result
+     * @param data data received in the result
+     * @return the uri of the image selected if the activity corresponds to a pick in the gallery, else null
+     */
     public static Uri handleActivityResultAndGetUri(int requestCode, int resultCode, Intent data) {
 
         if (requestCode == IMAGE_REQUEST && resultCode == RESULT_OK &&
@@ -73,10 +68,11 @@ public class ImagePicker {
         return null;
     }
 
-    /*public Uri getImageUri() {
-        return imageUri;
-    }*/
-
+    /**
+     * Uploads an image in the storage system and returns a download url
+     * @param imageUri the uri of the image to store
+     * @return a download url to get the image from the storage system
+     */
     public static Task<Uri> uploadImage(Uri imageUri) {
         Storage storage = DependencyManager.getStorageSystem();
         return storage.storeAndGetDownloadUrl(getFileExtension(imageUri), imageUri);

--- a/app/src/main/java/ch/epfl/sdp/kandle/imagePicker/ImagePicker.java
+++ b/app/src/main/java/ch/epfl/sdp/kandle/imagePicker/ImagePicker.java
@@ -11,6 +11,7 @@ import androidx.fragment.app.Fragment;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 
+import ch.epfl.sdp.kandle.Kandle;
 import ch.epfl.sdp.kandle.dependencies.DependencyManager;
 import ch.epfl.sdp.kandle.dependencies.Storage;
 
@@ -18,23 +19,12 @@ import static android.app.Activity.RESULT_OK;
 
 public class ImagePicker {
 
-    private Activity activity;
-    private Fragment fragment;
-    private Uri imageUri;
+    //private Activity activity;
+    //private Fragment fragment;
+    //private Uri imageUri;
 
     private static final int IMAGE_REQUEST = 1;
-
-    public ImagePicker(Activity activity) {
-        this.activity = activity;
-        this.fragment = null;
-    }
-
-    public ImagePicker(Fragment fragment) {
-        this.fragment = fragment;
-        this.activity = null;
-    }
-
-    public void openImage() {
+    /*public void openImage() {
         Intent intent = new Intent();
         intent.setType("image/*");
         intent.setAction(Intent.ACTION_GET_CONTENT);
@@ -44,32 +34,51 @@ public class ImagePicker {
         if (fragment != null) {
             fragment.startActivityForResult(intent, IMAGE_REQUEST);
         }
+    }*/
+
+    public static void openImage(Activity activity) {
+        Intent intent = pickerIntent();
+        activity.startActivityForResult(intent, IMAGE_REQUEST);
     }
 
-    protected String getFileExtension(Uri uri) {
-        ContentResolver contentResolver = activity != null ? activity.getContentResolver() : fragment.getContext().getContentResolver();
+    public static void openImage(Fragment fragment) {
+        Intent intent = pickerIntent();
+        fragment.startActivityForResult(intent, IMAGE_REQUEST);
+    }
+
+    private static Intent pickerIntent(){
+        Intent intent = new Intent();
+        intent.setType("image/*");
+        intent.setAction(Intent.ACTION_GET_CONTENT);
+        return intent;
+    }
+
+    /*private String getFileExtension(Uri uri) {
+        ContentResolver contentResolver = Kandle.getContext().getContentResolver();
+        return MimeTypeMap.getSingleton().getExtensionFromMimeType(contentResolver.getType(uri));
+    }*/
+
+    public static String getFileExtension(Uri uri) {
+        ContentResolver contentResolver = Kandle.getContext().getContentResolver();
         return MimeTypeMap.getSingleton().getExtensionFromMimeType(contentResolver.getType(uri));
     }
 
-    public void handleActivityResult(int requestCode, int resultCode, Intent data) {
+    public static Uri handleActivityResultAndGetUri(int requestCode, int resultCode, Intent data) {
 
         if (requestCode == IMAGE_REQUEST && resultCode == RESULT_OK &&
                 data != null && data.getData() != null) {
-            imageUri = data.getData();
+            return data.getData();
         }
+
+        return null;
     }
 
-    public Uri getImageUri() {
+    /*public Uri getImageUri() {
         return imageUri;
-    }
+    }*/
 
-    public Task<Uri> uploadImage() {
-        if (imageUri != null) {
-            Storage storage = DependencyManager.getStorageSystem();
-            return storage.storeAndGetDownloadUrl(getFileExtension(imageUri), imageUri);
-        }
-        TaskCompletionSource<Uri> result = new TaskCompletionSource<>();
-        result.setResult(null);
-        return result.getTask();
-    };
+    public static Task<Uri> uploadImage(Uri imageUri) {
+        Storage storage = DependencyManager.getStorageSystem();
+        return storage.storeAndGetDownloadUrl(getFileExtension(imageUri), imageUri);
+    }
 }

--- a/app/src/main/java/ch/epfl/sdp/kandle/imagePicker/ProfilePicPicker.java
+++ b/app/src/main/java/ch/epfl/sdp/kandle/imagePicker/ProfilePicPicker.java
@@ -11,6 +11,12 @@ import ch.epfl.sdp.kandle.dependencies.DependencyManager;
 
 public class ProfilePicPicker extends ImagePicker {
 
+
+    /**
+     * Replaces the profile picture of the connected user in the database and deletes the previous profile picture from the storage system
+     * @param imageUri the uri of the new profile picture
+     * @return a task finishing when the new profile picture has been stored and set in the database
+     */
     public static Task<Void> setProfilePicture(Uri imageUri) {
         DependencyManager.getDatabaseSystem().getProfilePicture().addOnCompleteListener(task -> {
             if (task.isSuccessful() && task.getResult() != null) {

--- a/app/src/main/java/ch/epfl/sdp/kandle/imagePicker/ProfilePicPicker.java
+++ b/app/src/main/java/ch/epfl/sdp/kandle/imagePicker/ProfilePicPicker.java
@@ -1,9 +1,6 @@
 package ch.epfl.sdp.kandle.imagePicker;
 
-import android.app.Activity;
 import android.net.Uri;
-
-import androidx.fragment.app.Fragment;
 
 import com.google.android.gms.tasks.Task;
 

--- a/app/src/main/java/ch/epfl/sdp/kandle/imagePicker/ProfilePicPicker.java
+++ b/app/src/main/java/ch/epfl/sdp/kandle/imagePicker/ProfilePicPicker.java
@@ -11,22 +11,14 @@ import ch.epfl.sdp.kandle.dependencies.DependencyManager;
 
 public class ProfilePicPicker extends ImagePicker {
 
-    public ProfilePicPicker(Activity activity) {
-        super(activity);
-    }
-
-    public ProfilePicPicker(Fragment fragment) {
-        super(fragment);
-    }
-
-    public Task<Void> setProfilePicture() {
+    public static Task<Void> setProfilePicture(Uri imageUri) {
         DependencyManager.getDatabaseSystem().getProfilePicture().addOnCompleteListener(task -> {
             if (task.isSuccessful() && task.getResult() != null) {
                 DependencyManager.getStorageSystem().delete(task.getResult());
             }
         });
 
-        return uploadImage().continueWithTask(task -> {
+        return uploadImage(imageUri).continueWithTask(task -> {
             String sUri = null;
             Uri downloadUri = task.getResult();
             if (downloadUri != null) {


### PR DESCRIPTION
Refactoring that makes all functions in ImagePicker static to avoid keeping a state, which involved unexpected behaviours when taking an image with the camera after having picked one from the gallery.
Also remove "save" button appearing in case the user press return from the gallery while editing his profile picture.